### PR TITLE
Necessary small fixes

### DIFF
--- a/docassemble/MichiganLetterToLandlordReRet/data/questions/michigan_letter_to_landlord_re__ret.yml
+++ b/docassemble/MichiganLetterToLandlordReRet/data/questions/michigan_letter_to_landlord_re__ret.yml
@@ -1,7 +1,7 @@
 include:
   - docassemble.AssemblyLine:assembly_line.yml
   - docassemble.ALAnyState:any_state.yml
-  - docassemble.mlhframeworkBH:mlh_interview_framework.yml
+  - docassemble.mlhframework:mlh_interview_framework.yml
 
 ---
 modules:
@@ -173,7 +173,7 @@ subquestion: |
 
 ---
 id: thirty days
-question: Did you move out more than 30 days ago (before ${ today() - timedelta(days=30) } )?
+question: Did you move out more than 30 days ago (before ${ today() - timedelta(days=30) })?
 fields:
   - no label: thirty_days
     datatype: yesnoradio


### PR DESCRIPTION
Finished up my review of the Letter to Landlord; made most of my questions and thoughts into issues, and put two really small fixes in this PR.

* Use `mlhframework` instead of `mlhframeworkBH`, which isn't publically available (that I can see).
* Get rid of user-visible extra space between a word an the closing paren

Since this is your repo, feel free to merge when you want, I'll avoid doing so to not make any conflicts with you.