### PR TITLE
remove extra asterisk from list on first screen

### DIFF
--- a/docassemble/MichiganLetterToLandlordReRet/data/questions/michigan_letter_to_landlord_re__ret.yml
+++ b/docassemble/MichiganLetterToLandlordReRet/data/questions/michigan_letter_to_landlord_re__ret.yml
@@ -156,7 +156,7 @@ subquestion: |
   
   * it has been more than **30 days** since you moved out of your old home,
   * you gave your previous landlord your **forwarding address** within **four days** of moving out of the home, 
-  * you did **not** get your **security deposit** or **a list of damages** from your previous landlord, ***and**
+  * you did **not** get your **security deposit** or **a list of damages** from your previous landlord, **and**
   * you have **not** gotten anything in writing explaining why your landlord kept some or all of your security deposit.
 
   ${ collapse_template(forwarding_address_template) }


### PR DESCRIPTION
@normon66 

Found an errant asterisk showing up here on first screen:
<img width="332" alt="image" src="https://github.com/mplp/docassemble-MichiganLetterToLandlordReRet/assets/110936328/d46df06e-0be3-48cc-a429-d8d1b3811e28">

with this change:
![image](https://github.com/mplp/docassemble-MichiganLetterToLandlordReRet/assets/110936328/0df91af1-9504-4a1c-93d7-ffa8902736d1)
